### PR TITLE
Expose server port via Pulumi config

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,12 @@ go run ./go-fractalizer
 ```
 
 Infrastructure to containerize and run the server using Pulumi is defined in `infra`.
+A sample stack configuration `Pulumi.dev.yaml` sets the port used by the container.
+You can deploy the stack with:
+
+```bash
+cd infra
+pulumi up
+```
+
+The port can be customized by editing the stack file or via `pulumi config set port <num>`.

--- a/infra/Pulumi.dev.yaml
+++ b/infra/Pulumi.dev.yaml
@@ -1,0 +1,2 @@
+config:
+  fractalizer-go:port: 8080

--- a/infra/main.go
+++ b/infra/main.go
@@ -1,37 +1,45 @@
 package main
 
 import (
-    docker "github.com/pulumi/pulumi-docker/sdk/v3/go/docker"
-    "github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"fmt"
+
+	docker "github.com/pulumi/pulumi-docker/sdk/v3/go/docker"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi/config"
 )
 
 func main() {
-    pulumi.Run(func(ctx *pulumi.Context) error {
-        image, err := docker.NewImage(ctx, "fractalizer-image", &docker.ImageArgs{
-            Build: docker.DockerBuildArgs{
-                Context: pulumi.String("../go-fractalizer"),
-            },
-            ImageName: pulumi.String("fractalizer:latest"),
-        })
-        if err != nil {
-            return err
-        }
+	pulumi.Run(func(ctx *pulumi.Context) error {
+		cfg := config.New(ctx, "")
+		port := cfg.GetInt("port")
+		if port == 0 {
+			port = 8080
+		}
 
-        _, err = docker.NewContainer(ctx, "fractalizer-container", &docker.ContainerArgs{
-            Image: image.ImageName,
-            Ports: docker.ContainerPortArray{
-                docker.ContainerPortArgs{
-                    Internal: pulumi.Int(8080),
-                    External: pulumi.Int(8080),
-                },
-            },
-        })
-        if err != nil {
-            return err
-        }
+		image, err := docker.NewImage(ctx, "fractalizer-image", &docker.ImageArgs{
+			Build: docker.DockerBuildArgs{
+				Context: pulumi.String("../go-fractalizer"),
+			},
+			ImageName: pulumi.String("fractalizer:latest"),
+		})
+		if err != nil {
+			return err
+		}
 
-        ctx.Export("endpoint", pulumi.String("http://localhost:8080"))
-        return nil
-    })
+		_, err = docker.NewContainer(ctx, "fractalizer-container", &docker.ContainerArgs{
+			Image: image.ImageName,
+			Ports: docker.ContainerPortArray{
+				docker.ContainerPortArgs{
+					Internal: pulumi.Int(port),
+					External: pulumi.Int(port),
+				},
+			},
+		})
+		if err != nil {
+			return err
+		}
+
+		ctx.Export("endpoint", pulumi.String(fmt.Sprintf("http://localhost:%d", port)))
+		return nil
+	})
 }
-


### PR DESCRIPTION
## Summary
- add sample Pulumi stack file with `port` setting
- make Docker container port configurable in Pulumi program
- document stack usage in README

## Testing
- `python3 -m py_compile fractal_explorer.py`
- `go mod tidy` *(fails: no route to host)*